### PR TITLE
NPL support, second index with Categories, searching for categories

### DIFF
--- a/EtsyClusterizer/build.gradle
+++ b/EtsyClusterizer/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compile group: 'org.apache.lucene', name: 'lucene-queryparser', version: '6.2.1'
     compile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.13'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
+    compile group: 'org.apache.opennlp', name: 'opennlp-tools', version: '1.6.0'
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'org.glassfish.jersey.containers:jersey-container-servlet:2.14'
 }

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/Main.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/Main.java
@@ -1,22 +1,16 @@
 package com.ir.etsy.clusterizer;
 
+import com.ir.etsy.clusterizer.categories.Category;
 import com.ir.etsy.clusterizer.listings.Listing;
 import com.ir.etsy.clusterizer.listings.ListingState;
-import com.ir.etsy.clusterizer.utils.EtsyListingUnmarshaller;
+import com.ir.etsy.clusterizer.utils.EtsyUnmarshaller;
 import com.ir.etsy.clusterizer.utils.IOUtils;
-import com.ir.etsy.clusterizer.utils.ListingProperties;
 import com.ir.etsy.clusterizer.utils.LuceneIndexUtils;
+import com.ir.etsy.clusterizer.utils.LuceneDocumentType;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.PhraseQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.TopDocs;
 
 /**
  *
@@ -24,42 +18,46 @@ import org.apache.lucene.search.TopDocs;
  */
 public class Main {
 
-    private static final String EXAMPLE_LISTINGS_FOLDER = "";
-    private static final String INDEX_DIR = "";
-
     public static void main(String[] args) throws IOException {
-        File[] files = IOUtils.getAllFiles(EXAMPLE_LISTINGS_FOLDER);
-        IndexWriter indexWriter = LuceneIndexUtils.createIndex(INDEX_DIR);
-        addDocuments(files, indexWriter);
-        LuceneIndexUtils.closeIndex(indexWriter);
-
-        IndexReader indexReader = LuceneIndexUtils.getIndexReader(INDEX_DIR);
-        IndexSearcher indexSearcher = LuceneIndexUtils.getIndexSearcher(indexReader);
-
-        Query query = new PhraseQuery(ListingProperties.TITLE, "chess", "board");
-
-        TopDocs results = indexSearcher.search(query, 100);
-
-        System.out.println("Found " + results.scoreDocs.length + " hits.");
-
-        for (ScoreDoc scoreDoc : results.scoreDocs) {
-            Document doc = indexSearcher.doc(scoreDoc.doc);
-            System.out.println(doc.get(ListingProperties.TITLE));
+        if (LuceneDocumentType.BASE_INDEX_DIR.isEmpty() || LuceneDocumentType.BASE_DATA_DIR.isEmpty()) {
+            throw new Error("Both LuceneDocumentType.BASE_INDEX_DIR and LuceneDocumentType.BASE_DATA_DIR" +
+                    " should be set to the correct directories before starting the indexing operation.");
         }
-
-        LuceneIndexUtils.closeIndex(indexReader);
+        
+        indexListingDocuments();
+        indexCategoryDocuments();
     }
 
-    private static void addDocuments(File[] files, IndexWriter indexWriter) throws IOException {
-        for (File file : files) {
+    private static void indexListingDocuments() throws IOException {
+        File[] listingFiles = IOUtils.getAllFiles(LuceneDocumentType.LISTING.getDataDir());
+        IndexWriter listingsIndexWriter = LuceneIndexUtils.createIndex(LuceneDocumentType.LISTING);
+        
+        for (File file : listingFiles) {
             System.out.println("Reading file " + file.getName());
-            List<Listing> listings = EtsyListingUnmarshaller.getListings(file);
+            List<Listing> listings = EtsyUnmarshaller.getListings(file);
             for (Listing listing : listings) {
                 // Strangely, there are some non-active items
                 if (listing.getState() == ListingState.ACTIVE) {
-                    indexWriter.addDocument(listing.toDocument());
+                    listingsIndexWriter.addDocument(listing.toDocument());
                 }
             }
         }
+        
+        LuceneIndexUtils.closeIndex(listingsIndexWriter);
+    }
+    
+    private static void indexCategoryDocuments() throws IOException {
+        File[] categoryFiles = IOUtils.getAllFiles(LuceneDocumentType.CATEGORY.getDataDir());
+        IndexWriter categoriesIndexWriter = LuceneIndexUtils.createIndex(LuceneDocumentType.CATEGORY);
+        
+        for (File file : categoryFiles) {
+            System.out.println("Reading file " + file.getName());
+            List<Category> categories = EtsyUnmarshaller.getCategories(file);
+            for (Category category : categories) {
+                categoriesIndexWriter.addDocument(category.toDocument());
+            }
+        }
+        
+        LuceneIndexUtils.closeIndex(categoriesIndexWriter);
     }
 }

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/categories/Category.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/categories/Category.java
@@ -1,0 +1,236 @@
+package com.ir.etsy.clusterizer.categories;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Category {
+
+    @JsonProperty(CategoryProperties.CATEGORY_ID)
+    protected Long categoryId;
+
+    @JsonProperty(CategoryProperties.NAME)
+    protected String name;
+
+    @JsonProperty(CategoryProperties.META_TITLE)
+    protected String metaTitle;
+
+    @JsonProperty(CategoryProperties.META_KEYWORDS)
+    protected String metaKeywords;
+
+    @JsonProperty(CategoryProperties.PAGE_TITLE)
+    protected String pageTitle;
+
+    @JsonProperty(CategoryProperties.SHORT_NAME)
+    protected String shortName;
+
+    @JsonProperty(CategoryProperties.NUM_CHILDREN)
+    protected Integer numChildren;
+
+    @JsonProperty(CategoryProperties.LEVEL)
+    protected Integer level;
+
+    @JsonProperty(CategoryProperties.PARENT_ID)
+    protected Long parentId;
+
+    @JsonProperty(CategoryProperties.GRANDPARENT_ID)
+    protected Long grandparentId;
+
+    public Category() {
+    }
+    
+    /**
+     * Creates a slim Category from a Document
+     *
+     * @param doc
+     */
+    public Category(Document doc) {
+        this.categoryId = Long.valueOf(doc.get(CategoryProperties.CATEGORY_ID));
+        this.metaTitle = doc.get(CategoryProperties.META_TITLE);
+        this.metaKeywords = doc.get(CategoryProperties.META_KEYWORDS);
+        this.level = Integer.valueOf(doc.get(CategoryProperties.LEVEL));
+        this.parentId = stringToLong(doc.get(CategoryProperties.PARENT_ID));
+        this.grandparentId = stringToLong(doc.get(CategoryProperties.GRANDPARENT_ID));
+    }
+    
+    private static Long stringToLong(String val) {
+        if (val == null || val.compareTo("null") == 0) {
+            return null;
+        }
+        return Long.valueOf(val);
+    }
+
+    public Document toDocument() {
+        Document doc = new Document();
+
+        doc.add(new StringField(CategoryProperties.CATEGORY_ID, String.valueOf(categoryId), Field.Store.YES));
+        doc.add(new TextField(CategoryProperties.META_TITLE, (metaTitle != null ? metaTitle : ""), Field.Store.YES));
+        doc.add(new TextField(CategoryProperties.META_KEYWORDS, (metaKeywords != null ? metaKeywords : ""), Field.Store.YES));
+        doc.add(new StringField(CategoryProperties.LEVEL, String.valueOf(level), Field.Store.YES));
+        doc.add(new StringField(CategoryProperties.PARENT_ID, String.valueOf(parentId), Field.Store.YES));
+        doc.add(new StringField(CategoryProperties.GRANDPARENT_ID, String.valueOf(grandparentId), Field.Store.YES));
+
+        return doc;
+    }
+
+    @Override
+    public String toString() {
+        return "Category{"
+                + "category_id=" + categoryId
+                + ", name=" + name
+                + ", metaTitle=" + metaTitle
+                + ", metaKeywords=" + metaKeywords
+                + ", pageTitle=" + pageTitle
+                + ", shortName=" + shortName
+                + ", numChildren=" + numChildren
+                + ", level=" + level
+                + ", parentId=" + parentId
+                + ", grandparentId=" + grandparentId + '}';
+    }
+
+    /**
+     * @return the categoryId
+     */
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    /**
+     * @param categoryId the categoryId to set
+     */
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the metaTitle
+     */
+    public String getMetaTitle() {
+        return metaTitle;
+    }
+
+    /**
+     * @param metaTitle the metaTitle to set
+     */
+    public void setMetaTitle(String metaTitle) {
+        this.metaTitle = metaTitle;
+    }
+
+    /**
+     * @return the metaKeywords
+     */
+    public String getMetaKeywords() {
+        return metaKeywords;
+    }
+
+    /**
+     * @param metaKeywords the metaKeywords to set
+     */
+    public void setMetaKeywords(String metaKeywords) {
+        this.metaKeywords = metaKeywords;
+    }
+
+    /**
+     * @return the pageTitle
+     */
+    public String getPageTitle() {
+        return pageTitle;
+    }
+
+    /**
+     * @param pageTitle the pageTitle to set
+     */
+    public void setPageTitle(String pageTitle) {
+        this.pageTitle = pageTitle;
+    }
+
+    /**
+     * @return the shortName
+     */
+    public String getShortName() {
+        return shortName;
+    }
+
+    /**
+     * @param shortName the shortName to set
+     */
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+
+    /**
+     * @return the numChildren
+     */
+    public Integer getNumChildren() {
+        return numChildren;
+    }
+
+    /**
+     * @param numChildren the numChildren to set
+     */
+    public void setNumChildren(Integer numChildren) {
+        this.numChildren = numChildren;
+    }
+
+    /**
+     * @return the level
+     */
+    public Integer getLevel() {
+        return level;
+    }
+
+    /**
+     * @param level the level to set
+     */
+    public void setLevel(Integer level) {
+        this.level = level;
+    }
+
+    /**
+     * @return the parentId
+     */
+    public Long getParentId() {
+        return parentId;
+    }
+
+    /**
+     * @param parentId the parentId to set
+     */
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    /**
+     * @return the grandparentId
+     */
+    public Long getGrandparentId() {
+        return grandparentId;
+    }
+
+    /**
+     * @param grandparentId the grandparentId to set
+     */
+    public void setGrandparentId(Long grandparentId) {
+        this.grandparentId = grandparentId;
+    }
+
+}

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/categories/CategoryProperties.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/categories/CategoryProperties.java
@@ -1,0 +1,16 @@
+package com.ir.etsy.clusterizer.categories;
+
+public class CategoryProperties {
+
+    public static final String CATEGORY_ID = "category_id";
+    public static final String NAME = "name";
+    public static final String META_TITLE = "meta_title";
+    public static final String META_KEYWORDS = "meta_keywords";
+    public static final String PAGE_TITLE = "page_title";
+    public static final String SHORT_NAME = "short_name";
+    public static final String NUM_CHILDREN = "num_children";
+    // LEVEL is 1-based! Valid values are in the range [1, 3]
+    public static final String LEVEL = "level";
+    public static final String PARENT_ID = "parent_id";
+    public static final String GRANDPARENT_ID = "grandparent_id";
+}

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/categories/CategoryRetriever.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/categories/CategoryRetriever.java
@@ -1,0 +1,69 @@
+package com.ir.etsy.clusterizer.categories;
+
+import com.ir.etsy.clusterizer.utils.LuceneDocumentType;
+import com.ir.etsy.clusterizer.utils.LuceneIndexUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+
+public class CategoryRetriever {
+    
+    private static final int MAX_RESULT_COUNT = 3;
+    
+    public static List<Category> getMatchingCategories(Set<String> terms, Long notThisCategoryId) throws IOException {
+        IndexReader indexReader = LuceneIndexUtils.getIndexReader(LuceneDocumentType.CATEGORY);
+        IndexSearcher indexSearcher = LuceneIndexUtils.getIndexSearcher(indexReader);
+        
+        String stringCategoryid = String.valueOf(notThisCategoryId);
+        
+        BooleanQuery query = buildBooleanQuery(terms, stringCategoryid);
+        TopDocs hits = indexSearcher.search(query, MAX_RESULT_COUNT);
+        
+        return prepareResult(indexSearcher, hits);
+    }
+
+    private static BooleanQuery buildBooleanQuery(Set<String> terms, String notThisCategoryId) {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        
+        for (String term : terms) {
+            Query query = new TermQuery(new Term(CategoryProperties.META_KEYWORDS, term));
+            builder.add(query, BooleanClause.Occur.SHOULD);
+            Query query2 = new TermQuery(new Term(CategoryProperties.META_TITLE, term));
+            builder.add(query2, BooleanClause.Occur.SHOULD);
+        }
+
+        Query sameCategoryQuery = new TermQuery(new Term(CategoryProperties.CATEGORY_ID, notThisCategoryId));
+        builder.add(sameCategoryQuery, BooleanClause.Occur.MUST_NOT);
+
+        BooleanQuery query = builder.build();
+        return query;
+    }
+
+    private static List<Category> prepareResult(IndexSearcher indexSearcher, TopDocs hits) throws IOException {
+        if (hits.totalHits == 0) {
+            return Collections.<Category>emptyList();
+        }
+
+        List<Category> results = new ArrayList<>();
+        for (ScoreDoc scoreDoc : hits.scoreDocs) {
+            Document doc = indexSearcher.doc(scoreDoc.doc);
+            results.add(new Category(doc));
+        }
+
+        return results;
+    }
+}

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/Listing.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/Listing.java
@@ -21,61 +21,61 @@ import org.codehaus.jackson.annotate.JsonProperty;
 public class Listing {
 
     @JsonProperty(ListingProperties.LISTING_ID)
-    private long listingId;
+    protected long listingId;
 
     @JsonProperty(ListingProperties.STATE)
-    private ListingState state;
+    protected ListingState state;
 
     @JsonProperty(ListingProperties.USER_ID)
-    private long userId;
+    protected long userId;
 
     @JsonProperty(ListingProperties.TITLE)
-    private String title;
+    protected String title;
 
     @JsonProperty(ListingProperties.CREATION_TSZ)
-    private long creationTsz;
+    protected long creationTsz;
 
     @JsonProperty(ListingProperties.ENDING_TSZ)
-    private long endingTsz;
+    protected long endingTsz;
 
     @JsonProperty(ListingProperties.TAGS)
-    private List<String> tags;
+    protected List<String> tags;
 
     @JsonProperty(ListingProperties.CATEGORY_PATH)
-    private List<String> categoryPath;
+    protected List<String> categoryPath;
 
     @JsonProperty(ListingProperties.CATEGORY_PATH_IDS)
-    private List<Long> categoryPathIds;
+    protected List<Long> categoryPathIds;
 
     @JsonProperty(ListingProperties.MATERIALS)
-    private List<String> materials;
+    protected List<String> materials;
 
     @JsonProperty(ListingProperties.VIEWS)
-    private int views;
+    protected int views;
 
     @JsonProperty(ListingProperties.NUM_FAVORERS)
-    private int numFavorers;
+    protected int numFavorers;
 
     @JsonProperty(ListingProperties.IS_SUPPLY)
-    private boolean isSupply;
+    protected boolean isSupply;
 
     @JsonProperty(ListingProperties.OCCASION)
-    private String occasion;
+    protected String occasion;
 
     @JsonProperty(ListingProperties.STYLE)
-    private List<String> style;
+    protected List<String> style;
 
     @JsonProperty(ListingProperties.HAS_VARIATION)
-    private boolean hasVariations;
+    protected boolean hasVariations;
 
     @JsonProperty(ListingProperties.SUGGESTED_TAXONOMY_ID)
-    private long suggestedTaxonomyId;
+    protected long suggestedTaxonomyId;
 
     @JsonProperty(ListingProperties.TAXONOMY_PATH)
-    private List<String> taxonomyPath;
+    protected List<String> taxonomyPath;
 
     @JsonProperty(ListingProperties.USED_MANUFACTURER)
-    private boolean usedManufacturer;
+    protected boolean usedManufacturer;
 
     public Listing() {
     }
@@ -92,7 +92,7 @@ public class Listing {
         this.categoryPathIds = pathAsList(doc);
     }
 
-    private List<Long> pathAsList(Document doc) {
+    protected List<Long> pathAsList(Document doc) {
         int categoryIndex = 0;
 
         String p = doc.get(ListingProperties.CATEGORY + (categoryIndex++));
@@ -121,8 +121,8 @@ public class Listing {
 
         int categoryIndex = 0;
         // There are only up to 3 categories in a hierarchy
-        for (Long category : categoryPathIds) {
-            doc.add(new StringField(ListingProperties.CATEGORY + (categoryIndex++), String.valueOf(category), Field.Store.YES));
+        for (String category : categoryPath) {
+            doc.add(new TextField(ListingProperties.CATEGORY + (categoryIndex++), category, Field.Store.YES));
         }
 
         addListItems(doc, materials, ListingProperties.MATERIALS);
@@ -136,7 +136,7 @@ public class Listing {
         return doc;
     }
 
-    private static void addListItems(Document doc, List<String> list, String fieldName) {
+    protected static void addListItems(Document doc, List<String> list, String fieldName) {
         for (String item : list) {
             doc.add(new TextField(fieldName, item, Field.Store.YES));
         }

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/Listing.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/Listing.java
@@ -1,6 +1,5 @@
 package com.ir.etsy.clusterizer.listings;
 
-import com.ir.etsy.clusterizer.utils.ListingProperties;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,18 +79,6 @@ public class Listing {
     public Listing() {
     }
 
-    /**
-     * Creates a tiny listing from a Document
-     *
-     * @param doc
-     */
-    public Listing(Document doc) {
-        this.listingId = Integer.valueOf(doc.get(ListingProperties.LISTING_ID));
-        this.title = doc.get(ListingProperties.TITLE);
-        this.tags = Arrays.asList(doc.getValues(ListingProperties.TAGS));
-        this.categoryPathIds = pathAsList(doc);
-    }
-
     protected List<Long> pathAsList(Document doc) {
         int categoryIndex = 0;
 
@@ -121,8 +108,8 @@ public class Listing {
 
         int categoryIndex = 0;
         // There are only up to 3 categories in a hierarchy
-        for (String category : categoryPath) {
-            doc.add(new TextField(ListingProperties.CATEGORY + (categoryIndex++), category, Field.Store.YES));
+        for (Long categoryId : categoryPathIds) {
+            doc.add(new StringField(ListingProperties.CATEGORY + (categoryIndex++), String.valueOf(categoryId), Field.Store.YES));
         }
 
         addListItems(doc, materials, ListingProperties.MATERIALS);

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/ListingProperties.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/ListingProperties.java
@@ -1,4 +1,4 @@
-package com.ir.etsy.clusterizer.utils;
+package com.ir.etsy.clusterizer.listings;
 
 /**
  *

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/ResultListing.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/ResultListing.java
@@ -1,6 +1,5 @@
 package com.ir.etsy.clusterizer.listings;
 
-import com.ir.etsy.clusterizer.utils.ListingProperties;
 import java.util.Arrays;
 import org.apache.lucene.document.Document;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -14,14 +13,13 @@ public class ResultListing extends Listing {
     }
     
      /**
-     * Creates a ResultListing from a Document
+     * Creates a slim ResultListing from a Document
      *
      * @param doc
      */
     public ResultListing(Document doc, float score) {
-        this.listingId = Integer.valueOf(doc.get(ListingProperties.LISTING_ID));
+        this.listingId = Long.valueOf(doc.get(ListingProperties.LISTING_ID));
         this.title = doc.get(ListingProperties.TITLE);
-        this.tags = Arrays.asList(doc.getValues(ListingProperties.TAGS));
         this.categoryPathIds = pathAsList(doc);
         this.score = score;
     }

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/ResultListing.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/ResultListing.java
@@ -1,0 +1,36 @@
+package com.ir.etsy.clusterizer.listings;
+
+import com.ir.etsy.clusterizer.utils.ListingProperties;
+import java.util.Arrays;
+import org.apache.lucene.document.Document;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class ResultListing extends Listing {
+    @JsonProperty("score")
+    protected float score;
+    
+    // For JSON serialization
+    public ResultListing() {
+    }
+    
+     /**
+     * Creates a ResultListing from a Document
+     *
+     * @param doc
+     */
+    public ResultListing(Document doc, float score) {
+        this.listingId = Integer.valueOf(doc.get(ListingProperties.LISTING_ID));
+        this.title = doc.get(ListingProperties.TITLE);
+        this.tags = Arrays.asList(doc.getValues(ListingProperties.TAGS));
+        this.categoryPathIds = pathAsList(doc);
+        this.score = score;
+    }
+    
+    public float getScore() {
+        return score;
+    }
+
+    public void setScore(float score) {
+        this.score = score;
+    }
+}

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/SimilarListingsRetriever.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/SimilarListingsRetriever.java
@@ -2,13 +2,17 @@ package com.ir.etsy.clusterizer.listings;
 
 import com.ir.etsy.clusterizer.utils.ListingProperties;
 import com.ir.etsy.clusterizer.utils.LuceneIndexUtils;
+import com.ir.etsy.clusterizer.nlp.NounExtractor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.mlt.MoreLikeThis;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -16,6 +20,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 
 /**
@@ -24,55 +29,53 @@ import org.apache.lucene.search.TopDocs;
  */
 public class SimilarListingsRetriever {
 
+    private static final int MAX_RESULT_COUNT = 50;
+
     //NOTE: change it to lead to your index.
     private static final String INDEX_DIR = "D:\\IR_project_etsy_files\\index";
 
-    public static List<Listing> findSimilar(Listing listing) throws IOException {
+    public static List<ResultListing> findSimilar(Listing listing) throws IOException {
         IndexReader indexReader = LuceneIndexUtils.getIndexReader(INDEX_DIR);
         IndexSearcher indexSearcher = LuceneIndexUtils.getIndexSearcher(indexReader);
+
+        TopDocs similarDocs = runCustomSearcher(listing, indexReader, indexSearcher);
 
         MoreLikeThis mlt = new MoreLikeThis(indexReader);
         mlt.setFieldNames(new String[]{
             ListingProperties.TITLE,
             ListingProperties.TAGS
         });
-        mlt.setAnalyzer(new StandardAnalyzer());
+        mlt.setAnalyzer(ListingAnalyzer.getAnalyzer());
 
         TopDocs originalListingSearch = indexSearcher.search(new PhraseQuery(ListingProperties.LISTING_ID, String.valueOf(listing.getListingId())), 1);
 
-        if (originalListingSearch.totalHits == 0) {
-            //Should not happen. But if happens - execute custom similarities searcher
-            return runCustomSearcher(listing, indexReader, indexSearcher);
+        if (originalListingSearch.totalHits != 0) {
+            Query query = mlt.like(originalListingSearch.scoreDocs[0].doc);
+            TopDocs mltDocs = indexSearcher.search(query, MAX_RESULT_COUNT);
+
+            if (mltDocs.totalHits != 0) {
+                // Will merge the results and leave the top MAX_RESULT_COUNT ones by score
+                similarDocs = TopDocs.merge(MAX_RESULT_COUNT, (new TopDocs []{similarDocs, mltDocs}));
+            }
         }
 
-        Query query = mlt.like(originalListingSearch.scoreDocs[0].doc);
-
-        TopDocs topHits = indexSearcher.search(query, 50);
-
-        if (topHits.totalHits == 0) {
-            return runCustomSearcher(listing, indexReader, indexSearcher);
-        }
-
-        return prepareResult(indexSearcher, topHits);
+        return prepareResult(indexSearcher, similarDocs);
     }
 
-    private static List<Listing> runCustomSearcher(Listing listing, IndexReader reader, IndexSearcher indexSearcher) throws IOException {
+    private static TopDocs runCustomSearcher(Listing listing, IndexReader reader, IndexSearcher indexSearcher) throws IOException {
+        String title = listing.getTitle();
         List<String> tags = listing.getTags();
         List<String> materials = listing.getMaterials();
-        List<Long> categories = listing.getCategoryPathIds();
-        BooleanQuery query = buildBooleanQuery(tags, materials, categories);
+        List<String> categories = listing.getCategoryPath();
+        BooleanQuery query = buildBooleanQuery(title, tags, materials, categories);
         TopDocs hits = indexSearcher.search(query, 50);
-        return prepareResult(indexSearcher, hits);
+        return hits;
     }
 
-    public static List<Listing> runCustomSearcher(Listing listing) throws IOException {
-        IndexReader indexReader = LuceneIndexUtils.getIndexReader(INDEX_DIR);
-        IndexSearcher indexSearcher = LuceneIndexUtils.getIndexSearcher(indexReader);
-        return runCustomSearcher(listing, indexReader, indexSearcher);
-    }
-
-    private static BooleanQuery buildBooleanQuery(List<String> tags, List<String> materials, List<Long> categories) {
+    private static BooleanQuery buildBooleanQuery(String title, List<String> tags, List<String> materials, List<String> categories) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        Set<String> titleNouns = NounExtractor.extractNouns(title);
+
         for (String tag : tags) {
             Query query = new PhraseQuery(ListingProperties.TAGS, tag);
             builder.add(query, BooleanClause.Occur.SHOULD);
@@ -89,19 +92,26 @@ public class SimilarListingsRetriever {
             builder.add(query, BooleanClause.Occur.SHOULD);
         }
 
+        // Search the nouns from the title in other listings' tags
+        for (String titleNoun : titleNouns) {
+            Query query = new TermQuery(new Term(ListingProperties.TAGS, titleNoun));
+            builder.add(query, BooleanClause.Occur.SHOULD);
+        }
+
         BooleanQuery query = builder.build();
         return query;
     }
 
-    private static List<Listing> prepareResult(IndexSearcher indexSearcher, TopDocs hits) throws IOException {
+    private static List<ResultListing> prepareResult(IndexSearcher indexSearcher, TopDocs hits) throws IOException {
         if (hits.totalHits == 0) {
-            return Collections.<Listing>emptyList();
+            return Collections.<ResultListing>emptyList();
         }
 
-        List<Listing> results = new ArrayList<>();
+        List<ResultListing> results = new ArrayList<>();
         for (ScoreDoc scoreDoc : hits.scoreDocs) {
             Document doc = indexSearcher.doc(scoreDoc.doc);
-            results.add(new Listing(doc));
+            ResultListing res = new ResultListing(doc, scoreDoc.score);
+            results.add(res);
         }
 
         return results;

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/SimilarListingsRetriever.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/listings/SimilarListingsRetriever.java
@@ -1,15 +1,15 @@
 package com.ir.etsy.clusterizer.listings;
 
-import com.ir.etsy.clusterizer.utils.ListingProperties;
+import com.ir.etsy.clusterizer.categories.Category;
+import com.ir.etsy.clusterizer.categories.CategoryRetriever;
 import com.ir.etsy.clusterizer.utils.LuceneIndexUtils;
 import com.ir.etsy.clusterizer.nlp.NounExtractor;
+import com.ir.etsy.clusterizer.utils.LuceneDocumentType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
@@ -31,11 +31,8 @@ public class SimilarListingsRetriever {
 
     private static final int MAX_RESULT_COUNT = 50;
 
-    //NOTE: change it to lead to your index.
-    private static final String INDEX_DIR = "D:\\IR_project_etsy_files\\index";
-
     public static List<ResultListing> findSimilar(Listing listing) throws IOException {
-        IndexReader indexReader = LuceneIndexUtils.getIndexReader(INDEX_DIR);
+        IndexReader indexReader = LuceneIndexUtils.getIndexReader(LuceneDocumentType.LISTING);
         IndexSearcher indexSearcher = LuceneIndexUtils.getIndexSearcher(indexReader);
 
         TopDocs similarDocs = runCustomSearcher(listing, indexReader, indexSearcher);
@@ -55,24 +52,73 @@ public class SimilarListingsRetriever {
 
             if (mltDocs.totalHits != 0) {
                 // Will merge the results and leave the top MAX_RESULT_COUNT ones by score
+                // XXX: not sure these are normalized before that
                 similarDocs = TopDocs.merge(MAX_RESULT_COUNT, (new TopDocs []{similarDocs, mltDocs}));
             }
         }
 
         return prepareResult(indexSearcher, similarDocs);
     }
+    
+    // TODO: wire-in with the other logic. Currently rarely returns any results
+    public static List<ResultListing> expandSearchWithSimilarCategories(Listing listing) throws IOException {
+        List<Long> categoryPathIds = listing.getCategoryPathIds();
+        if (categoryPathIds.isEmpty()) {
+            return Collections.<ResultListing>emptyList();
+        }
+        
+        IndexReader indexReader = LuceneIndexUtils.getIndexReader(LuceneDocumentType.LISTING);
+        IndexSearcher indexSearcher = LuceneIndexUtils.getIndexSearcher(indexReader);
+
+        String title = listing.getTitle();
+        Set<String> titleNouns = NounExtractor.extractNouns(title);
+        Long mostSpecificCategoryId = categoryPathIds.get(categoryPathIds.size() - 1);
+
+        // Search the nouns from the title in category keywords
+        List<Category> categories = CategoryRetriever.getMatchingCategories(titleNouns, mostSpecificCategoryId);
+        
+        if (categories.isEmpty()) {
+            return Collections.<ResultListing>emptyList();
+        }
+        
+        BooleanQuery query = buildCategoriesBooleanQuery(categories);
+        TopDocs docs = indexSearcher.search(query, MAX_RESULT_COUNT);
+
+        return prepareResult(indexSearcher, docs);
+    }
+    
+    private static BooleanQuery buildCategoriesBooleanQuery(List<Category> categories) {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+
+        for (Category category : categories) {
+            BooleanQuery.Builder categoryQueryBuilder = new BooleanQuery.Builder();
+            // Level is 1-based
+            Integer level = category.getLevel();
+            Long categoryId = category.getCategoryId();
+
+            Query query = new PhraseQuery(ListingProperties.CATEGORY+(level-1), String.valueOf(categoryId));
+            categoryQueryBuilder.add(query, BooleanClause.Occur.MUST);
+            BooleanQuery categoryQuery = categoryQueryBuilder.build();
+
+            builder.add(categoryQuery, BooleanClause.Occur.SHOULD);
+            break;
+        }
+
+        BooleanQuery query = builder.build();
+        return query;
+    }
 
     private static TopDocs runCustomSearcher(Listing listing, IndexReader reader, IndexSearcher indexSearcher) throws IOException {
         String title = listing.getTitle();
         List<String> tags = listing.getTags();
         List<String> materials = listing.getMaterials();
-        List<String> categories = listing.getCategoryPath();
+        List<Long> categories = listing.getCategoryPathIds();
         BooleanQuery query = buildBooleanQuery(title, tags, materials, categories);
-        TopDocs hits = indexSearcher.search(query, 50);
+        TopDocs hits = indexSearcher.search(query, MAX_RESULT_COUNT);
         return hits;
     }
 
-    private static BooleanQuery buildBooleanQuery(String title, List<String> tags, List<String> materials, List<String> categories) {
+    private static BooleanQuery buildBooleanQuery(String title, List<String> tags, List<String> materials, List<Long> categories) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         Set<String> titleNouns = NounExtractor.extractNouns(title);
 

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/nlp/NounExtractor.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/nlp/NounExtractor.java
@@ -1,7 +1,5 @@
 package com.ir.etsy.clusterizer.nlp;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
@@ -38,9 +36,6 @@ public class NounExtractor {
                 getNouns(parseResults[0], nouns);
             }
         } catch (IOException e) {
-            Set<String> fakeNouns = new HashSet<>();
-            fakeNouns.add("baby");
-            return fakeNouns;
         } finally {
             if (null != modelIn) {
                 try {

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/nlp/NounExtractor.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/nlp/NounExtractor.java
@@ -1,0 +1,65 @@
+package com.ir.etsy.clusterizer.nlp;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import opennlp.tools.cmdline.parser.ParserTool;
+import opennlp.tools.parser.Parse;
+import opennlp.tools.parser.Parser;
+import opennlp.tools.parser.ParserFactory;
+import opennlp.tools.parser.ParserModel;
+
+// Extracts the nouns from a single sentence using Apache OpenNLP
+public class NounExtractor {
+    
+    public static final String NOUN_LABEL = "NN";
+
+	public static Set<String> extractNouns(String sentence) {
+        // So we have only the unique nouns
+        Set<String> nouns = new HashSet<>();
+
+        InputStream modelIn = null;
+        try {
+            // Load pre-trained model file, taken from http://opennlp.sourceforge.net/models-1.5/
+            ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+            modelIn = classloader.getResourceAsStream("/en-parser-chunking.bin");
+            ParserModel model = new ParserModel(modelIn);
+
+            // Create parser
+            Parser parser = ParserFactory.create(model);
+            // Request only a single parse result (the top one)
+            Parse parseResults[] = ParserTool.parseLine(sentence, parser, 1);
+            
+            if (parseResults.length > 0) {
+                getNouns(parseResults[0], nouns);
+            }
+        } catch (IOException e) {
+            Set<String> fakeNouns = new HashSet<>();
+            fakeNouns.add("baby");
+            return fakeNouns;
+        } finally {
+            if (null != modelIn) {
+                try {
+                    modelIn.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+
+        return nouns;
+	}
+
+	// Recursively loop through the parse tree extracting the nouns
+	private static void getNouns(Parse p, Set<String> nouns) {
+	    if (p.getType().equals(NOUN_LABEL)) {
+	         nouns.add(p.getCoveredText());
+	    }
+	    for (Parse child : p.getChildren()) {
+            getNouns(child, nouns);
+        }
+	}
+}

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/services/EtsyResource.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/services/EtsyResource.java
@@ -1,6 +1,6 @@
 package com.ir.etsy.clusterizer.services;
 
-import com.ir.etsy.clusterizer.listings.Listing;
+import com.ir.etsy.clusterizer.listings.ResultListing;
 import com.ir.etsy.clusterizer.listings.SimilarListingsRetriever;
 import java.io.IOException;
 import java.util.List;
@@ -26,8 +26,8 @@ public class EtsyResource {
         ObjectMapper mapper = new ObjectMapper();
 
         try {
-            Listing listing = mapper.readValue(json, Listing.class);
-            List<Listing> similarListings = SimilarListingsRetriever.findSimilar(listing);
+            ResultListing listing = mapper.readValue(json, ResultListing.class);
+            List<ResultListing> similarListings = SimilarListingsRetriever.findSimilar(listing);
 
             String jsonResult = mapper.writeValueAsString(similarListings);
 

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/utils/EtsyUnmarshaller.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/utils/EtsyUnmarshaller.java
@@ -1,5 +1,6 @@
 package com.ir.etsy.clusterizer.utils;
 
+import com.ir.etsy.clusterizer.categories.Category;
 import com.ir.etsy.clusterizer.listings.Listing;
 import java.io.File;
 import java.io.IOException;
@@ -10,12 +11,17 @@ import org.codehaus.jackson.map.ObjectMapper;
  *
  * @author Dimitar
  */
-public class EtsyListingUnmarshaller {
+public class EtsyUnmarshaller {
 
     public static List<Listing> getListings(File listingsFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         List<Listing> listings = mapper.readValue(listingsFile, mapper.getTypeFactory().constructCollectionType(List.class, Listing.class));
         return listings;
     }
-
+    
+    public static List<Category> getCategories(File categoriesFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        List<Category> categories = mapper.readValue(categoriesFile, mapper.getTypeFactory().constructCollectionType(List.class, Category.class));
+        return categories;
+    }
 }

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/utils/IOUtils.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/utils/IOUtils.java
@@ -1,6 +1,7 @@
 package com.ir.etsy.clusterizer.utils;
 
 import java.io.File;
+import java.nio.file.Path;
 import org.apache.commons.lang3.Validate;
 
 /**
@@ -9,12 +10,9 @@ import org.apache.commons.lang3.Validate;
  */
 public class IOUtils {
 
-    public static File[] getAllFiles(String directory) {
-        Validate.notEmpty(directory);
-        return getAllFiles(new File(directory));
-    }
-
-    public static File[] getAllFiles(File directory) {
+    public static File[] getAllFiles(Path directoryPath) {
+        Validate.notNull(directoryPath);
+        File directory = directoryPath.toFile();
         Validate.notNull(directory);
         return directory.listFiles();
     }

--- a/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/utils/LuceneDocumentType.java
+++ b/EtsyClusterizer/src/main/java/com/ir/etsy/clusterizer/utils/LuceneDocumentType.java
@@ -1,0 +1,28 @@
+package com.ir.etsy.clusterizer.utils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public enum LuceneDocumentType {
+    LISTING ("listings", "listings"),
+    CATEGORY ("categories", "categories");
+    
+    public static final String BASE_INDEX_DIR = "";
+    public static final String BASE_DATA_DIR = "";
+    
+    private final String indexSubdir;
+    private final String dataSubdir;
+            
+    LuceneDocumentType(String indexSubdir, String dataSubdir) {
+        this.indexSubdir = indexSubdir;
+        this.dataSubdir = dataSubdir;
+    }
+    
+    public Path getIndexDir() {
+        return Paths.get(BASE_INDEX_DIR, indexSubdir);
+    }
+    
+    public Path getDataDir() {
+        return Paths.get(BASE_DATA_DIR, dataSubdir);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Install Apache Tomcat if necessary.
 
 Modify the `webAppsFolder` definition in `build.gradle` to point to your Apache Tomcat installation.
 
-Modify `INDEX_DIR` in `SimilarListingsRetriever.java`.
+Modify the `BASE_INDEX_DIR` and `BASE_DATA_DIR` constants in `SimilarListingsRetriever.java`.
 
-Modify `INDEX_DIR` and `EXAMPLE_LISTINGS_FOLDER` (the dir with [data JSONs](https://drive.google.com/drive/folders/0B5iTVLqLnNC6SlVHRXMxSkFheU0?usp=sharing)) in `Main.java`.
+`BASE_DATA_DIR` should point to a directory that has `categories` and `listings` subdirectories.
+Download and add the correspondig data JSON files there from [here](https://drive.google.com/drive/folders/0B5iTVLqLnNC6SlVHRXMxSkFheU0?usp=sharing).
 
-Run the EtsyClusterizer project so the index is generated (you can do it through NetBeans if you install Gradle plugin and add the project).
+Run the EtsyClusterizer project so the indexes are generated (you can do it through NetBeans if you install Gradle plugin and add the project).
 
 In the root folder run `gradle build` - this will also copy the .war to the webserver folder.
 


### PR DESCRIPTION
NLP part:
- Added the Apache OpenNLP library and a `NounExtractor` class that uses it.
Based on the work of @mimipaskova 
- The custom search in `SimilarListingsRetriever` now uses the nouns from the title of the given listing to search for in other listings' tags.
     - Included a big binary file (`en-parser-chunking.bin`) in the resources - otherwise the config becomes quite fragile.
- Tweaked the searching in `SimilarListingsRetriever` - now the custom search is performed first, then Lucene's `MoreLikeThis` and the results are combined.
- Added a new class `ResultListing` to be returned from `SimilarListingsRetriever` - contains everything from the `Listing` + a new field - `score` - as returned from Lucene.
    
----    
**Follow the updated `README.md` to index the new data!**    
----    
    
Category part:
- Added support for a second type of document - `Category`.
- Moved all directory constants to the new `LuceneDocumentType` class.
- Added `CategoryRetriever` to get categories by a set of strings (looks for them in the category title and keywords).
- The `expandSearchWithSimilarCategories` in `SimilarListingsRetriever` is implemented but not called from anywhere currently.
     - Searches for categories (again based on the nouns from the title of the given listing). Expands the result set of listings with items from these categories.
     - Seems to rarely return any results for 2 reasons: nouns cannot always be extracted (or there aren't such in the titles), category keywords a pretty specific (and available only for the top 2 levels of categories).